### PR TITLE
Usage warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,19 @@
 
 Die Schnittstelle ermöglicht das automatisierte Auslesen von Vorgängen in KreditSmart.
 
+> :warning: Diese Schnittstelle wird kontinuierlich weiterentwickelt. Daher erwarten wir 
+> von allen Nutzern dieser Schnittstelle, dass sie das "Tolerant Reader Pattern" nutzen, d.h. 
+> tolerant gegenüber kompatiblen API Änderungen beim Lesen und Prozessieren der Daten sind:
+>
+> 1. unbekannte Felder dürfen keine Fehler verursachen
+>
+> 2. Strings mit eingeschränktem Wertebereich (Enums) müssen mit neuen, unbekannten Werten umgehen können
+>
+> 3. sinnvoller Umgang mit HTTP-Statuscodes die nicht explizit dokumentiert sind  
+> 
+ 
+<!-- https://opensource.zalando.com/restful-api-guidelines/#108 -->
+ 
 # Table of Contents
 
 * [Allgemeines](#allgemeines)
@@ -216,7 +229,7 @@ Für einen erfolgreichen Request muss die Query in folgendem Format vorhanden se
       "antraege": [Antrag]
     }
     
-Beachte: "letzteAenderungAm" zeigt NUR die letzte Änderung der Vorgangs-Daten an. Für Änderungen an den Anträgen wird das Feld "letzteAenderungAm" in jedem Antrag befüllt.
+:heavy_exclamation_mark: "letzteAenderungAm" zeigt NUR die letzte Änderung der Vorgangs-Daten an. Für Änderungen an den Anträgen wird das Feld "letzteAenderungAm" in jedem Antrag befüllt.
 
 
 ### Partner
@@ -274,7 +287,7 @@ Die Angabe *gemeinsamerHaushalt* ist nur beim zweiten Antragsteller ausgefüllt.
       "selbststaendiger": Selbstständiger
     }
 
-Die befüllten Felder zur Beschäftigung sind abhängig von der Beschäftigungsart.  
+:heavy_exclamation_mark: Die befüllten Felder zur Beschäftigung sind abhängig von der Beschäftigungsart.  
 __Beispiel:__ *beschaeftigungsart=ARBEITER*, dann wird der Knoten *arbeiter* befüllt
 
 ##### Arbeiter und Angestellter

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Die Schnittstelle ermöglicht das automatisierte Auslesen von Vorgängen in Kred
 >
 > 2. Strings mit eingeschränktem Wertebereich (Enums) müssen mit neuen, unbekannten Werten umgehen können
 >
-> 3. sinnvoller Umgang mit HTTP-Statuscodes die nicht explizit dokumentiert sind  
+> 3. sinnvoller Umgang mit HTTP-Statuscodes, die nicht explizit dokumentiert sind  
 > 
  
 <!-- https://opensource.zalando.com/restful-api-guidelines/#108 -->

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 Die Schnittstelle ermöglicht das automatisierte Auslesen von Vorgängen in KreditSmart.
 
 > :warning: Diese Schnittstelle wird kontinuierlich weiterentwickelt. Daher erwarten wir 
-> von allen Nutzern dieser Schnittstelle, dass sie das "Tolerant Reader Pattern" nutzen, d.h. 
-> tolerant gegenüber kompatiblen API Änderungen beim Lesen und Prozessieren der Daten sind:
+> von allen Nutzern dieser Schnittstelle, dass sie das "[Tolerant Reader Pattern](https://martinfowler.com/bliki/TolerantReader.html)" nutzen, d.h. 
+> tolerant gegenüber kompatiblen API-Änderungen beim Lesen und Prozessieren der Daten sind:
 >
 > 1. unbekannte Felder dürfen keine Fehler verursachen
 >


### PR DESCRIPTION
Ich möchte in der Doku gern klarer machen, was wir als non-breaking-change ansehen, damit die Clients sich darauf vorbereiten können. 

Am liebsten hätte ich dafür eine admonition-box, aber da bin ich am Markdown von Github gescheitert @gesellix hast du dafür noch eine bessere Idee?